### PR TITLE
Fix bug when eliding keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ Just a list of keys you'd be interested to use on fields - look at http://docs.d
 Datomic has defaults for:
 
 ```
-:db/cardinality <:db.cardinality/one>
 :db/index <false>
 :db/fulltext <false>
 :db/noHistory <false>
@@ -157,6 +156,8 @@ This behavior can be overridden by passing in `false` as the last argument:
 
 Passing in `false` will elide those Datomic default keys, unless of course your `schema`
 defines non-default values.
+
+Note, that Datomic requires that `:db/cardinality` be explicitly set for each attribute installed. `generate-schema` will default to `:db.cardinality/one` unless the `schema` passed in specifies otherwise.
 
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,4 @@
   :url "http://www.github.com/Yuppiechef/datomic-schema"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [])
+  :dependencies [[org.clojure/clojure "1.5.0"]])

--- a/src/datomic_schema/schema.clj
+++ b/src/datomic_schema/schema.clj
@@ -48,12 +48,13 @@
         (cond-> {:db.install/_attribute :db.part/db
                  :db/id (tempid-fn :db.part/db)
                  :db/ident (keyword basename fieldname)
-                 :db/valueType dbtype}
+                 :db/valueType dbtype
+                 :db/cardinality (if (opts :many)
+                                   :db.cardinality/many
+                                   :db.cardinality/one)}
                 (or gen-all? (opts :indexed)) (assoc :db/index (boolean (opts :indexed)))
                 (or gen-all? (seq (filter string? opts))) (assoc :db/doc
                                                            (or (first (filter string? opts)) ""))
-                (or gen-all? (opts :many)) (assoc :db/cardinality
-                                             (if (opts :many) :db.cardinality/many :db.cardinality/one))
                 (or gen-all? (opts :fulltext)) (assoc :db/fulltext (boolean (opts :fulltext)))
                 (or gen-all? (opts :component)) (assoc :db/isComponent (boolean (opts :component)))
                 (or gen-all? (opts :nohistory)) (assoc :db/noHistory (boolean (opts :nohistory))))]


### PR DESCRIPTION
Sorry, it looks like :db/cardinality is a required key when installing a Datomic attribute. My spot testing earlier didn't pick this up. I'd add a few tests, but I'm a bit too swamped at the moment.