### PR TITLE
Don't automatically namespace partition names

### DIFF
--- a/src/datomic_schema/schema.clj
+++ b/src/datomic_schema/schema.clj
@@ -23,7 +23,7 @@
 
 (defn part
   [nm]
-  (keyword "db.part" nm))
+  (keyword nm))
 
 ;; The datomic schema conversion functions
 (defn get-enums [basens part enums]
@@ -49,10 +49,10 @@
              :db/cardinality (if (opts :many) :db.cardinality/many :db.cardinality/one)}
           (or index-all? gen-all? (opts :indexed))
           (assoc :db/index (boolean (or index-all? (opts :indexed))))
-          
+
           (or gen-all? (seq (filter string? opts)))
           (assoc :db/doc (or (first (filter string? opts)) ""))
-          
+
           (or gen-all? (opts :fulltext)) (assoc :db/fulltext (boolean (opts :fulltext)))
           (or gen-all? (opts :component)) (assoc :db/isComponent (boolean (opts :component)))
           (or gen-all? (opts :nohistory)) (assoc :db/noHistory (boolean (opts :nohistory))))]


### PR DESCRIPTION
Users should have the flexibility to namespace partitions however they like (or not at all, as shown in the Datomic docs).
