### PR TITLE
Do not add basename prefix to enum idents if basename is nil

### DIFF
--- a/src/datomic_schema/schema.clj
+++ b/src/datomic_schema/schema.clj
@@ -59,7 +59,7 @@
     (concat
      acc
      [(if uniq (assoc result :db/unique uniq) result)]
-     (if (= type :enum) (get-enums (str basename "." fieldname) part (first (filter vector? opts)))))))
+     (if (= type :enum) (get-enums (if basename (str basename "." fieldname) fieldname) part (first (filter vector? opts)))))))
 
 (defn schema->datomic [opts acc schema]
   (if (or (:db/id schema) (vector? schema))


### PR DESCRIPTION
I need a schema where different entity types share the same enum, my solution was to define a field outside of the 'schema' macro.

When creating an enum with 'fields' outside of 'schema', enum idents with an empty basename prefix are generated.

For example, with the following schema, i get `[:.event-type/a :.event-type/b :.event-type/c]` as enum idents.

```clojure
  (generate-schema
   [(schema metric
            (fields
             [event-type :ref]
             [value :long]
             [instant :instant]))

    (schema other-metric
            (fields
             [event-type :ref]
             [value :long]
             [instant :instant]))
    
    (fields
     [event-type :enum [:a :b :c]])
])
```

This PR adds a simple check on the basename set by 'schema' to that when the basename is nil, 
no basename prefix is used for enums. The schema above then generates `[:event-type/a :event-type/b :event-type/c]` as enum idents, which is a more intuitive result IMO

