### PR TITLE
do not apply namespace to attribute if none has been supplied. this w…

### DIFF
--- a/src/datomic_schema/schema.clj
+++ b/src/datomic_schema/schema.clj
@@ -44,7 +44,8 @@
         (cond->
             {:db.install/_attribute :db.part/db
              :db/id (d/tempid :db.part/db)
-             :db/ident (keyword basename fieldname)
+             :db/ident (if basename (keyword basename fieldname)
+                          (keyword fieldname))
              :db/valueType dbtype
              :db/cardinality (if (opts :many) :db.cardinality/many :db.cardinality/one)}
           (or index-all? gen-all? (opts :indexed))


### PR DESCRIPTION
…ill allow clients to specify fully qualified ns as string, e.g. 'foo/bar'