### PR TITLE
Feature/defdbfn implicit do

### DIFF
--- a/src/datomic_schema/schema.clj
+++ b/src/datomic_schema/schema.clj
@@ -49,10 +49,10 @@
              :db/cardinality (if (opts :many) :db.cardinality/many :db.cardinality/one)}
           (or index-all? gen-all? (opts :indexed))
           (assoc :db/index (boolean (or index-all? (opts :indexed))))
-          
+
           (or gen-all? (seq (filter string? opts)))
           (assoc :db/doc (or (first (filter string? opts)) ""))
-          
+
           (or gen-all? (opts :fulltext)) (assoc :db/fulltext (boolean (opts :fulltext)))
           (or gen-all? (opts :component)) (assoc :db/isComponent (boolean (opts :component)))
           (or gen-all? (opts :nohistory)) (assoc :db/noHistory (boolean (opts :nohistory))))]
@@ -84,12 +84,13 @@
 
 (defmacro dbfn
   [name params partition & code]
-  `{:db/id (datomic.api/tempid ~partition)
-    :db/ident ~(keyword name)
-    :db/fn (df/construct
-            {:lang "clojure"
-             :params '~params
-             :code '~@code})})
+  (let [code-in-do `(do ~@code)]
+    `{:db/id (datomic.api/tempid ~partition)
+      :db/ident ~(keyword name)
+      :db/fn (df/construct
+              {:lang "clojure"
+               :params '~params
+               :code '~code-in-do})}))
 
 (defmacro defdbfn
   "Define a datomic database function. All calls to datomic api's should be namespaced with datomic.api/ and you cannot use your own namespaces (since the function runs inside datomic)

--- a/test/datomic_schema/schematest.clj
+++ b/test/datomic_schema/schematest.clj
@@ -115,3 +115,15 @@
         (assert (= 10506 (:asset/value (uuid-ent c asset))))))
     (finally
       (d/delete-database duri))))
+
+(defdbfn with-assertion [db txs] :db.part/user
+  (assert txs "first argument must be provided")
+  txs)
+
+(deftest database-functions []
+  (let [c (d/connect duri)]
+    @(d/transact c (dbfns->datomic with-assertion))
+    @(d/transact c [[:with-assertion [{:db/id (d/tempid :db.part/user)
+                                       :db/ident :foo}]]])
+    (assert (d/entid (d/db c) :foo) ":foo must be transacted")
+    ))


### PR DESCRIPTION
Changes the `dbfn` macro to wrap the function body in an implicit do.

This is done because otherwise datomic will only use the first form, as demonstrated by the test added in
4043bf9

