### PR TITLE
Allow specifying :db.alter/_attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,14 @@ Just a list of keys you'd be interested to use on fields - look at http://docs.d
 ;; Options
 :unique-value :unique-identity :indexed :many :fulltext :component
 :nohistory "Some doc string" [:arbitrary "Enum" :values]
+:alter!
 ```
+
+### Altering schema
+
+If you need to update an option of an existing field - add an `:alter!` option
+key. This way a `:db.alter/_attribute` will be generated instead of a default
+`:db.install/_attribute`.
 
 ## Datomic defaults:
 Datomic has defaults for:

--- a/src/datomic_schema/schema.clj
+++ b/src/datomic_schema/schema.clj
@@ -42,7 +42,7 @@
         dbtype (keyword "db.type" (if (= type :enum) "ref" (name type)))
         result
         (cond->
-            {:db.install/_attribute :db.part/db
+            {(if (:alter! opts) :db.alter/_attribute :db.install/_attribute) :db.part/db
              :db/id (d/tempid :db.part/db)
              :db/ident (keyword basename fieldname)
              :db/valueType dbtype


### PR DESCRIPTION
New option - `:alter!`, to be used when one needs to alter a field.