### PR TITLE
Preserve enum keyword if namespaced

### DIFF
--- a/src/datomic_schema/schema.clj
+++ b/src/datomic_schema/schema.clj
@@ -28,7 +28,10 @@
 ;; The datomic schema conversion functions
 (defn get-enums [basens part enums]
   (map (fn [n]
-         (let [nm (if (string? n) (.replaceAll (.toLowerCase ^String n) " " "-") (name n))]
+         (let [basens (if-let [n (and (keyword? n) (namespace n))] n basens)
+               nm (if (string? n)
+                    (.replaceAll (.toLowerCase ^String n) " " "-")
+                    (name n))]
            [:db/add (d/tempid part) :db/ident (keyword basens nm)])) enums))
 
 (def unique-mapping

--- a/test/datomic_schema/schematest.clj
+++ b/test/datomic_schema/schematest.clj
@@ -22,6 +22,7 @@
     (fields
      [serial :string]
      [tag :enum [:computer :furniture :expensive :cheap :consumable] :many]
+     [ns-tag :enum [:the/computer :very/expensive]]
      [datepurchased :instant]
      [value :long]
      [deflationrate :float]
@@ -90,6 +91,7 @@
              :base/dateadded (java.util.Date.)
              :asset/serial "1234"
              :asset/tag [:asset.tag/computer :asset.tag/expensive]
+             :asset/ns-tag [:the/computer :very/expensive]
              :asset/datepurchased #inst "2014-12-25"
              :asset/value 10200
              :asset/deflationrate 12.445


### PR DESCRIPTION
If the enum value is specified as a namespaced keyword - do not append the `${schema}.${attribute}` namespace.

Sometimes I want to use the enum keywords across different schemas which is painful when they get autoprefixed with unique namespaces. 

It's a breaking change in case someone was using namespaced keywords as enum values and expecting the namespaces to be replaced by the `${schema}.${attribute}` combination.

Consider the following declaration: `(schema s [field :enum [:my.ns/value1 :value2 "value3"]])`

Before patch:

  * `idents = [:s.field/value1, :s.field/value2, :s.field/value3]`

After patch:

 *  `idents = [:my.ns/value1, :s.field/value2, :s.field/value3]`

I think the behaviour after applying this patch is more intuitive.
